### PR TITLE
remove git feature in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,6 @@
 		"--security-opt",
 		"seccomp=unconfined"
 	],
-
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"lldb.executable": "/usr/bin/lldb",
@@ -25,7 +24,6 @@
 		},
 		"rust-analyzer.checkOnSave.command": "clippy"
 	},
-
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"vadimcn.vscode-lldb",
@@ -34,16 +32,10 @@
 		"tamasfe.even-better-toml",
 		"serayuzgur.crates"
 	],
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
-
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
-	"features": {
-		"git": "latest"
-	}
 }


### PR DESCRIPTION
building git in devcontainer takes a long time and serves no purpose for the training. 